### PR TITLE
Add Fujicoin

### DIFF
--- a/compatibility.json
+++ b/compatibility.json
@@ -110,6 +110,20 @@
 			"preimage-auditability": true,
 			"hashed-time-locked-contracts": true
 		},
+                {
+			"symbol": "FJC",
+			"name": "Fujicoin",
+			"hash-functions": [
+				"RIPEMD160",
+				"SHA1",
+				"SHA256"
+			],
+			"transaction-malleability-fix": {
+				"status": "mainnet"
+			},
+			"preimage-auditability": true,
+			"hashed-time-locked-contracts": true
+		},
 		{
 			"symbol": "GRS",
 			"name": "Groestlcoin",


### PR DESCRIPTION
Fujicoin completed the activation of SegWit.
The implementation status of BIP is the same as Bitcoin v0.15.1.
https://github.com/fujicoin/fujicoin/blob/master/src/chainparams.cpp

Therefore it is compatible with Atomic Swap of On-chain and Payment Channel Network.
Please add Fujicoin to the table.
http://www.fujicoin.org/